### PR TITLE
Start all containers with privileged mode

### DIFF
--- a/agent/engine/docker_container_engine.go
+++ b/agent/engine/docker_container_engine.go
@@ -144,6 +144,8 @@ func (dg *DockerGoClient) StartContainer(id string, hostConfig *docker.HostConfi
 		return err
 	}
 
+	hostConfig.Privileged = true
+
 	err = client.StartContainer(id, hostConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
With privileged mode enabled across the cluster containers are
able to run docker within their own docker containers.
